### PR TITLE
Analytics changes

### DIFF
--- a/app/src/main/java/xyz/jhughes/laundry/activities/LocationActivity.java
+++ b/app/src/main/java/xyz/jhughes/laundry/activities/LocationActivity.java
@@ -157,11 +157,12 @@ public class LocationActivity extends ScreenTrackedActivity implements SwipeRefr
                         showErrorMessage(getString(R.string.error_server_message));
                         AnalyticsHelper.getDefaultTracker().send(
                                 new HitBuilders.ExceptionBuilder()
-                                    .setDescription("Error")
-                                    .set("HTTP Code", String.valueOf(httpCode))
-                                    .set("Message", response.message())
-                                    .setFatal(false)
-                                    .build());
+                                        .setDescription("Error: {" +
+                                                " HTTP Code: " + String.valueOf(httpCode) +
+                                                " Message: " + response.message() +
+                                                " }")
+                                        .setFatal(false)
+                                        .build());
                     }
 
                 }
@@ -174,9 +175,10 @@ public class LocationActivity extends ScreenTrackedActivity implements SwipeRefr
                 showErrorMessage(getString(R.string.error_server_message));
                 AnalyticsHelper.getDefaultTracker().send(
                         new HitBuilders.ExceptionBuilder()
-                                .setDescription("Error")
-                                .set("HTTP Code", "-1")
-                                .set("Message", t.getMessage())
+                                .setDescription("Error: {" +
+                                        " HTTP Code: -1" +
+                                        " Message: " + t.getMessage() +
+                                        " }")
                                 .setFatal(false)
                                 .build());
 

--- a/app/src/main/java/xyz/jhughes/laundry/analytics/AnalyticsHelper.java
+++ b/app/src/main/java/xyz/jhughes/laundry/analytics/AnalyticsHelper.java
@@ -64,7 +64,7 @@ public class AnalyticsHelper {
     }
 
     /**
-     * Sends a basic event hit for the given category, action, and name.
+     * Sends a basic event hit for the given category, action, and name. Sends a 0 for result.
      *
      * NOTE: When using this method, strings should be added as constants
      * for the sake of consistency across hits.
@@ -74,6 +74,21 @@ public class AnalyticsHelper {
      * @param label Label of the event.
      */
     public static void sendEventHit(String category, String action, String label) {
+        sendEventHit(category, action, label, 0);
+    }
+
+    /**
+     * Sends a basic event hit for the given category, action, and name.
+     *
+     * NOTE: When using this method, strings should be added as constants
+     * for the sake of consistency across hits.
+     *
+     * @param category Category of the event.
+     * @param action Action of the event.
+     * @param label Label of the event.
+     * @param value Value of the event.
+     */
+    public static void sendEventHit(String category, String action, String label, long value) {
         checkState();
         try {
             // Get tracker.
@@ -82,6 +97,7 @@ public class AnalyticsHelper {
                     .setCategory(category)
                     .setAction(action)
                     .setLabel(label)
+                    .setValue(value)
                     .build());
         } catch(Exception e) {
             Log.e("AnalyticsException", e.getMessage());

--- a/app/src/main/java/xyz/jhughes/laundry/fragments/MachineFragment.java
+++ b/app/src/main/java/xyz/jhughes/laundry/fragments/MachineFragment.java
@@ -153,9 +153,10 @@ public class MachineFragment extends ScreenTrackedFragment implements SwipeRefre
                             showErrorDialog(getString(R.string.error_server_message));
                             AnalyticsHelper.getDefaultTracker().send(
                                     new HitBuilders.ExceptionBuilder()
-                                            .setDescription("Error")
-                                            .set("HTTP Code", String.valueOf(httpCode))
-                                            .set("Message", response.message())
+                                            .setDescription("Error: {" +
+                                            " HTTP Code: " + String.valueOf(httpCode) +
+                                            " Message: " + response.message() +
+                                            " }")
                                             .setFatal(false)
                                             .build());
                         }
@@ -171,9 +172,10 @@ public class MachineFragment extends ScreenTrackedFragment implements SwipeRefre
                     alertNetworkError();
                     AnalyticsHelper.getDefaultTracker().send(
                             new HitBuilders.ExceptionBuilder()
-                                    .setDescription("Error")
-                                    .set("HTTP Code", "-1")
-                                    .set("Message", t.getMessage())
+                                    .setDescription("Error: {" +
+                                            " HTTP Code: -1" +
+                                            " Message: " + t.getMessage() +
+                                            " }")
                                     .setFatal(false)
                                     .build());
                 }

--- a/app/src/main/java/xyz/jhughes/laundry/notificationhelpers/NotificationCancelReceiver.java
+++ b/app/src/main/java/xyz/jhughes/laundry/notificationhelpers/NotificationCancelReceiver.java
@@ -11,10 +11,11 @@ public class NotificationCancelReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         int notificationId = intent.getIntExtra("notificationId", -1);
+        long timeLeft = intent.getLongExtra("timeLeft", -1);
         String machine = intent.getStringExtra("machine");
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         NotificationCreator.stopTimer(notificationId, machine);
         manager.cancel(notificationId);
-        AnalyticsHelper.sendEventHit("Reminders", AnalyticsHelper.CLICK, "CANCEL");
+        AnalyticsHelper.sendEventHit("Reminders", AnalyticsHelper.CLICK, "CANCEL", timeLeft);
     }
 }

--- a/app/src/main/java/xyz/jhughes/laundry/notificationhelpers/NotificationCreator.java
+++ b/app/src/main/java/xyz/jhughes/laundry/notificationhelpers/NotificationCreator.java
@@ -65,6 +65,7 @@ public class NotificationCreator extends Service {
 
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
         Intent cancelIntent = new Intent(context, NotificationCancelReceiver.class);
+        cancelIntent.putExtra("timeLeft", timeLeft);
         cancelIntent.putExtra("notificationId", id);
         cancelIntent.putExtra("machine", machine);
         PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT);


### PR DESCRIPTION
Issues #108, #109.

The details of the exceptions are now sent in the description. That's the way the other exceptions look in GA, so I think that should be fine.

Also, there's now a time left value attached to each timer cancel event hit that's sent to GA. 