### PR TITLE
Fixed crash with filters after orientation change

### DIFF
--- a/app/src/main/java/xyz/jhughes/laundry/adapters/AppSectionsPagerAdapter.java
+++ b/app/src/main/java/xyz/jhughes/laundry/adapters/AppSectionsPagerAdapter.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
+import android.view.ViewGroup;
 
 import xyz.jhughes.laundry.fragments.MachineFragment;
 
@@ -13,6 +14,9 @@ import xyz.jhughes.laundry.fragments.MachineFragment;
 public class AppSectionsPagerAdapter extends FragmentPagerAdapter {
     private String mRoomName;
     private MachineFragment mFragments[];
+    public static final int WASHERTABPOSITION = 0;
+    public static final int DRYERTABPOSITION = 1;
+
 
     public AppSectionsPagerAdapter(FragmentManager fm, String roomName) {
         super(fm);
@@ -24,22 +28,32 @@ public class AppSectionsPagerAdapter extends FragmentPagerAdapter {
         this.mRoomName = mRoomName;
     }
 
+    // Do NOT try to save references to the Fragments in getItem(),
+    // because getItem() is not always called. If the Fragment
+    // was already created then it will be retrieved from the FragmentManger
+    // and not here (i.e. getItem() won't be called again).
     @Override
     public Fragment getItem(int i) {
         Bundle b = new Bundle();
-        if(mFragments[i] == null) {
-            mFragments[i] = new MachineFragment();
-            b.putString("roomName", mRoomName);
-            if(i == 0) {
-                //The washers fragment
-                b.putBoolean("isDryers", false);
-            } else if (i == 1) {
-                // The dryers fragment
-                b.putBoolean("isDryers", true);
-            }
-            mFragments[i].setArguments(b);
+        Fragment fragment;
+        fragment = new MachineFragment();
+        b.putString("roomName", mRoomName);
+        if(i == WASHERTABPOSITION) {
+            //The washers fragment
+            b.putBoolean("isDryers", false);
+        } else if (i == DRYERTABPOSITION) {
+            // The dryers fragment
+            b.putBoolean("isDryers", true);
         }
-        return mFragments[i];
+        fragment.setArguments(b);
+        return fragment;
+    }
+
+    @Override
+    public Object instantiateItem(ViewGroup container, int position) {
+        MachineFragment fragment = (MachineFragment) super.instantiateItem(container, position);
+        mFragments[position] = fragment;
+        return fragment;
     }
 
     public void notifyFilterChanged() {
@@ -61,9 +75,9 @@ public class AppSectionsPagerAdapter extends FragmentPagerAdapter {
     @Override
     public CharSequence getPageTitle(int position) {
         switch (position) {
-            case 0:
+            case WASHERTABPOSITION:
                 return "Washers";
-            case 1:
+            case DRYERTABPOSITION:
                 return "Dryers";
             default:
                 return Integer.toString(position);


### PR DESCRIPTION
This resolves #116. 

This issue came up because in a ViewPager ,especially a fragmentViewPager, getItem() is only called when there is not already an item in the fragment manager. 

So, when we change the orientation, the viewpager is recreated and then finds all of its items in the FragmentManager. (thus not calling getItem() again on the second run). 

So after the orientation change, mFragments[] only has null items, causing the crash when trying to tell the fragments to refresh the filter. 