### PR TITLE
Updating travis to match new gradle versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ android:
     - tools # to get the new `repository-11.xml`
     - tools # see https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943)
     - platform-tools
-    - build-tools-24.0.2
-    - android-24
+    - build-tools-25.0.2
+    - android-25
     
     - extra-google-google_play_services
     - extra-google-m2repository


### PR DESCRIPTION
I am pushing this to a PR during my work on it because travis builds PR'd branches for me, which I need in order to test. 

Only merge after this message is updated. 