### PR TITLE
Timer tutorial

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         applicationId "xyz.jhughes.laundry"
         minSdkVersion 16
         targetSdkVersion 24
-        versionCode 9
+        versionCode 10
         versionName "2.3"
     }
     buildTypes {

--- a/app/src/main/java/xyz/jhughes/laundry/activities/MachineActivity.java
+++ b/app/src/main/java/xyz/jhughes/laundry/activities/MachineActivity.java
@@ -2,8 +2,10 @@ package xyz.jhughes.laundry.activities;
 
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.BaseTransientBottomBar;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.design.widget.TabLayout;
@@ -31,6 +33,13 @@ import xyz.jhughes.laundry.storage.SharedPrefsHelper;
  * This activity tracks screen views. The fragments ALSO track screen views.
  */
 public class MachineActivity extends ScreenTrackedActivity {
+    private static final String SHOW_ONBOARDING_COUNTDOWN = "show_onboarding_countdown";
+
+    /**
+     * The number of times to show the snackbar explaining how to start a timer
+     * unless the user manually dismisses it.
+     */
+    private static final int ONBOARDING_COUNTDOWN = 5;
 
     private String currentRoom;
     private AppSectionsPagerAdapter appSectionsPagerAdapter;
@@ -46,6 +55,8 @@ public class MachineActivity extends ScreenTrackedActivity {
     CoordinatorLayout mMainContent;
 
     Snackbar filterWarningBar;
+
+    Snackbar mOnboardingSnackbar;
 
     @Override
     protected void onPause() {
@@ -74,6 +85,76 @@ public class MachineActivity extends ScreenTrackedActivity {
         setUpViewPager();
         setScreenName(Constants.getApiLocation(currentRoom));
         updateFilteringWarning();
+
+        showOnboardingIfNecessary();
+    }
+
+
+    /**
+     * When the user first accesses the Machines Activity, we should show
+     * a snackbar telling them how to create a timer. We hope this will increase
+     * the use of timers.
+     */
+    private void showOnboardingIfNecessary() {
+        int numberOfTimesToShowOnboarding =
+                SharedPrefsHelper.getSharedPrefs(this).getInt(SHOW_ONBOARDING_COUNTDOWN, ONBOARDING_COUNTDOWN);
+
+        if((mOnboardingSnackbar != null && !mOnboardingSnackbar.isShown()))
+            return;
+
+        //add BuildConfig.DEBUG to this statement to make it display always for testing.
+        if(numberOfTimesToShowOnboarding > 0) {
+            //show onboarding snackbar.
+            mOnboardingSnackbar = Snackbar
+                    .make(mMainContent,
+                            "Tap a running machine be notified when it finishes.",
+                            Snackbar.LENGTH_INDEFINITE)
+                    .addCallback(new BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                        /**
+                         * If the user dismisses the snackbar, we should respect their
+                         * desire to not show the tutorial again.
+                         * We do this by setting the countdown to zero.
+                         */
+                        @Override
+                        public void onDismissed(Snackbar transientBottomBar, int event) {
+                            super.onDismissed(transientBottomBar, event);
+                            if(event == DISMISS_EVENT_SWIPE) {
+                                SharedPrefsHelper
+                                        .getSharedPrefs(MachineActivity.this)
+                                        .edit()
+                                        .putInt(SHOW_ONBOARDING_COUNTDOWN,
+                                                0)
+                                        .apply();
+                            }
+                        }
+                    })
+                    .setAction("Don't show again", new View.OnClickListener() {
+
+                        /**
+                         * If the user dismisses the snackbar, we should respect their
+                         * desire to not show the tutorial again.
+                         * We do this by setting the countdown to zero.
+                         */
+                        @Override
+                        public void onClick(View v) {
+                            SharedPrefsHelper
+                                    .getSharedPrefs(MachineActivity.this)
+                                    .edit()
+                                    .putInt(SHOW_ONBOARDING_COUNTDOWN,
+                                            0)
+                                    .apply();
+                        }
+                    });
+
+            mOnboardingSnackbar.show();
+
+            SharedPrefsHelper
+                    .getSharedPrefs(this)
+                    .edit()
+                    .putInt(SHOW_ONBOARDING_COUNTDOWN,
+                            --numberOfTimesToShowOnboarding)
+                    .apply();
+        }
     }
 
     private void updateFilteringWarning() {

--- a/app/src/main/java/xyz/jhughes/laundry/activities/MachineActivity.java
+++ b/app/src/main/java/xyz/jhughes/laundry/activities/MachineActivity.java
@@ -107,7 +107,7 @@ public class MachineActivity extends ScreenTrackedActivity {
             //show onboarding snackbar.
             mOnboardingSnackbar = Snackbar
                     .make(mMainContent,
-                            "Tap a running machine be notified when it finishes.",
+                            "Tap a running machine to be notified when it finishes.",
                             Snackbar.LENGTH_INDEFINITE)
                     .addCallback(new BaseTransientBottomBar.BaseCallback<Snackbar>() {
                         /**


### PR DESCRIPTION
# References
Fixes #70 to compliment #112. 

# Description
This will show a snackbar when the user opens the MachineActivity to help them know how to start a timer. 

# Notes
This PR includes code from #113, this should be taken into consideration when merging. It should not cause conflicts, but make sure #113 is approved FIRST. 

# Concerns
This can get a little odd when used with #113, despite requiring it. When the snackbar for the filters is shown, the one for timers cannot be. Take a close look at this interaction because I am not sure what I think about it yet. 