### PR TITLE
Fixes a bug that would have occurred from the merging of timer-onboard…

### DIFF
--- a/app/src/main/java/xyz/jhughes/laundry/fragments/MachineFragment.java
+++ b/app/src/main/java/xyz/jhughes/laundry/fragments/MachineFragment.java
@@ -263,7 +263,7 @@ public class MachineFragment extends ScreenTrackedFragment implements SwipeRefre
                     postSnackbar(getString(R.string.fragment_offline_location), Snackbar.LENGTH_LONG);
                     return;
                 }
-                currentAdapter.registerNotification(m);
+                currentAdapter.createNotification(m);
             }
         });
     }


### PR DESCRIPTION
…ing where the register notification method would attempt to create a dialog for an available machine while the create notification method will simply create the notification